### PR TITLE
feat(cli): install official ldcli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+Configure LaunchDarkly profile state for shell usage and install the official `ldcli`.
 
 ## Contributing
 
@@ -36,6 +36,7 @@ TODO: Add a short summary of this module.
 ##### p6df-launchdarkly/init.zsh
 
 - `p6df::modules::launchdarkly::deps()`
+- `p6df::modules::launchdarkly::external::brew()`
 - `p6df::modules::launchdarkly::init(_module, dir)`
   - Args:
     - _module - 
@@ -47,6 +48,14 @@ TODO: Add a short summary of this module.
     - env - 
 - `p6df::modules::launchdarkly::vscodes()`
 - `str str = p6df::modules::launchdarkly::prompt::mod()`
+
+## ENV
+
+- `P6_DFZ_PROFILE_LAUNCHDARKLY`
+- `P6_LD_PROJECT`
+- `P6_LD_ENV`
+- `LAUNCHDARKLY_API_KEY`
+- `LAUNCHDARKLY_SDK_KEY`
 
 #### p6df-launchdarkly/lib
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
 - `p6df::modules::launchdarkly::external::brew()`
 - `p6df::modules::launchdarkly::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::launchdarkly::profile::off()`
 - `p6df::modules::launchdarkly::profile::on(profile, env)`
   - Args:
-    - profile - 
-    - env - 
+    - profile -
+    - env -
 - `p6df::modules::launchdarkly::vscodes()`
 - `str str = p6df::modules::launchdarkly::prompt::mod()`
 
-## ENV
+### ENV
 
 - `P6_DFZ_PROFILE_LAUNCHDARKLY`
 - `P6_LD_PROJECT`
@@ -63,13 +63,13 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
 
 - `stream  = p6_launchdarkly_auditlog_for(flag, project, env, api_key)`
   - Args:
-    - flag - 
-    - project - 
-    - env - 
-    - api_key - 
-- `stream  = p6df::modules::launchdarkly::auditlog::for(flag, [project=$P6_LD_PROJECT], [env=$P6_LD_ENV], [api_key=$LAUNCHDARKLY_API_KEY])`
+    - flag -
+    - project -
+    - env -
+    - api_key -
+- `stream  = p6df::modules::launchdarkly::auditlog::for(flag, [project], [env], [api_key])`
   - Args:
-    - flag - 
+    - flag -
     - OPTIONAL project - [$P6_LD_PROJECT]
     - OPTIONAL env - [$P6_LD_ENV]
     - OPTIONAL api_key - [$LAUNCHDARKLY_API_KEY]

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
 - `LAUNCHDARKLY_API_KEY`
 - `LAUNCHDARKLY_SDK_KEY`
 
-#### p6df-launchdarkly/lib
+### p6df-launchdarkly/lib
 
-##### p6df-launchdarkly/lib/auditlog.sh
+#### p6df-launchdarkly/lib/auditlog.sh
 
 - `stream  = p6_launchdarkly_auditlog_for(flag, project, env, api_key)`
   - Args:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Code of Conduct](#code-of-conduct)
 - [Usage](#usage)
   - [Functions](#functions)
+- [ENV](#env)
 - [Hierarchy](#hierarchy)
 - [Author](#author)
 
@@ -49,14 +50,6 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
 - `p6df::modules::launchdarkly::vscodes()`
 - `str str = p6df::modules::launchdarkly::prompt::mod()`
 
-### ENV
-
-- `P6_DFZ_PROFILE_LAUNCHDARKLY`
-- `P6_LD_PROJECT`
-- `P6_LD_ENV`
-- `LAUNCHDARKLY_API_KEY`
-- `LAUNCHDARKLY_SDK_KEY`
-
 ### p6df-launchdarkly/lib
 
 #### p6df-launchdarkly/lib/auditlog.sh
@@ -73,6 +66,14 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
     - OPTIONAL project - [$P6_LD_PROJECT]
     - OPTIONAL env - [$P6_LD_ENV]
     - OPTIONAL api_key - [$LAUNCHDARKLY_API_KEY]
+
+## ENV
+
+- `P6_DFZ_PROFILE_LAUNCHDARKLY`
+- `P6_LD_PROJECT`
+- `P6_LD_ENV`
+- `LAUNCHDARKLY_API_KEY`
+- `LAUNCHDARKLY_SDK_KEY`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -13,6 +13,21 @@ p6df::modules::launchdarkly::deps() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::launchdarkly::external::brew()
+#
+#>
+######################################################################
+p6df::modules::launchdarkly::external::brew() {
+
+  brew tap launchdarkly/homebrew-tap
+  brew install ldcli
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::launchdarkly::vscodes()
 #
 #>


### PR DESCRIPTION
## Summary
- add `p6df::modules::launchdarkly::external::brew()`
- install the official LaunchDarkly CLI via Homebrew tap
- document the CLI-backed module shape and active env vars

## Local validation
- `shellcheck -e SC2034 init.zsh lib/auditlog.sh`
- `bash -n init.zsh lib/auditlog.sh`
- `brew tap launchdarkly/homebrew-tap && brew install ldcli`
- `ldcli --help`