### PR TITLE
feat: add mcp() hook to install @launchdarkly/mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 - [Code of Conduct](#code-of-conduct)
 - [Usage](#usage)
   - [Functions](#functions)
-- [ENV](#env)
 - [Hierarchy](#hierarchy)
 - [Author](#author)
 
@@ -18,7 +17,8 @@
 
 ## Summary
 
-Configure LaunchDarkly profile state for shell usage and install the official `ldcli`.
+Configure LaunchDarkly profile state for shell usage, install the official `ldcli`,
+and MCP server (`@launchdarkly/mcp-server`) for AI-driven feature flag management.
 
 ## Contributing
 
@@ -40,51 +40,45 @@ Configure LaunchDarkly profile state for shell usage and install the official `l
 - `p6df::modules::launchdarkly::external::brew()`
 - `p6df::modules::launchdarkly::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
+- `p6df::modules::launchdarkly::mcp()`
 - `p6df::modules::launchdarkly::profile::off()`
 - `p6df::modules::launchdarkly::profile::on(profile, env)`
   - Args:
-    - profile -
-    - env -
+    - profile
+    - env
 - `p6df::modules::launchdarkly::vscodes()`
 - `str str = p6df::modules::launchdarkly::prompt::mod()`
 
-### p6df-launchdarkly/lib
+#### p6df-launchdarkly/lib
 
-#### p6df-launchdarkly/lib/auditlog.sh
+##### p6df-launchdarkly/lib/auditlog.sh
 
 - `stream  = p6_launchdarkly_auditlog_for(flag, project, env, api_key)`
   - Args:
-    - flag -
-    - project -
-    - env -
-    - api_key -
-- `stream  = p6df::modules::launchdarkly::auditlog::for(flag, [project], [env], [api_key])`
+    - flag
+    - project
+    - env
+    - api_key
+- `stream  = p6df::modules::launchdarkly::auditlog::for(flag, [project=$P6_LD_PROJECT], [env=$P6_LD_ENV], [api_key=$LAUNCHDARKLY_API_KEY])`
   - Args:
-    - flag -
+    - flag
     - OPTIONAL project - [$P6_LD_PROJECT]
     - OPTIONAL env - [$P6_LD_ENV]
     - OPTIONAL api_key - [$LAUNCHDARKLY_API_KEY]
-
-## ENV
-
-- `P6_DFZ_PROFILE_LAUNCHDARKLY`
-- `P6_LD_PROJECT`
-- `P6_LD_ENV`
-- `LAUNCHDARKLY_API_KEY`
-- `LAUNCHDARKLY_SDK_KEY`
 
 ## Hierarchy
 
 ```text
 .
+├── bin
 ├── init.zsh
 ├── lib
 │   └── auditlog.sh
 └── README.md
 
-2 directories, 3 files
+3 directories, 3 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -95,6 +95,20 @@ p6df::modules::launchdarkly::prompt::mod() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::launchdarkly::mcp()
+#
+#>
+######################################################################
+p6df::modules::launchdarkly::mcp() {
+
+  p6_js_npm_global_install "@launchdarkly/mcp-server"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::launchdarkly::profile::on(profile, env)
 #
 #  Args:


### PR DESCRIPTION
## Summary

- `mcp()`: installs `@launchdarkly/mcp-server` for AI-driven feature flag management
- No `mcp::env()` needed: `profile::on` uses `p6_run_code` to set `LAUNCHDARKLY_API_KEY`
  and `LAUNCHDARKLY_SDK_KEY` directly — no additional mapping required

## Test plan

- [ ] `p6df mcp p6df-launchdarkly` installs `@launchdarkly/mcp-server`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)