### PR TITLE
chore: replace raw brew/curl/jq with p6df/p6common stdlib wrappers

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -19,8 +19,8 @@ p6df::modules::launchdarkly::deps() {
 ######################################################################
 p6df::modules::launchdarkly::external::brew() {
 
-  brew tap launchdarkly/homebrew-tap
-  brew install ldcli
+  p6df::core::homebrew::cmd::brew tap launchdarkly/homebrew-tap
+  p6df::core::homebrew::cmd::brew install ldcli
 
   p6_return_void
 }

--- a/lib/auditlog.sh
+++ b/lib/auditlog.sh
@@ -49,10 +49,10 @@ p6_launchdarkly_auditlog_for() {
   local env="$3"
   local api_key="$4"
 
-  curl -s \
+  p6_curl -s \
 	--location "https://app.launchdarkly.com/api/v2/auditlog?spec=proj%2F{$project}%3Aenv%2F${env}%3Aflag/${flag}"  \
 	--header "authorization: $api_key" | \
-	jq -r '.items[] | "\(.date)\t\(.title)"' | \
+	p6_json_eval -r '.items[] | "\(.date)\t\(.title)"' | \
 	p6_filter_translate_ms_epoch_to_iso8601_local
 
   p6_return_stream


### PR DESCRIPTION
## Summary

- **Issue 18** (`init.zsh`): Replace `brew tap`/`brew install` with `p6df::core::homebrew::cmd::brew` wrappers
- **Issue 19** (`lib/auditlog.sh`): Replace `curl | jq` with `p6_curl | p6_json_eval`

## Test plan

- [ ] `p6df::modules::launchdarkly::external::brew` installs ldcli correctly
- [ ] `p6_launchdarkly_auditlog_for` returns formatted audit log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)