### PR TITLE
ci: add merge_group trigger to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request: {}
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Summary
- Add `merge_group: types: [checks_requested]` to `build.yml`
- Without this, the build check never fires when PRs enter the merge queue
- The queue waits for `build` to pass, times out, and ejects the PR

## Test plan
- [ ] PRs in the merge queue now get a build check run and merge cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)