### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -13,11 +13,11 @@ p6df::modules::launchdarkly::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::launchdarkly::external::brew()
+# Function: p6df::modules::launchdarkly::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::launchdarkly::external::brew() {
+p6df::modules::launchdarkly::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap launchdarkly/homebrew-tap
   p6df::core::homebrew::cmd::brew install ldcli


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly