### PR TITLE
fix(prompt): replace launchdarkly prompt::mod and profile on/off with profile::mod pattern

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -7,7 +7,7 @@
 #>
 ######################################################################
 p6df::modules::launchdarkly::deps() {
-  ModuleDeps=()
+  ModuleDeps=(p6m7g8-dotfiles/p6common)
 }
 
 ######################################################################
@@ -42,59 +42,6 @@ p6df::modules::launchdarkly::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::launchdarkly::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-p6df::modules::launchdarkly::init () {
-	local _module="$1"
-	local dir="$2"
-
-	p6_bootstrap "$dir"
-
-	p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::launchdarkly::prompt::mod()
-#
-#  Returns:
-#	str - str
-#
-#  Environment:	 LAUNCHDARKLY_API_KEY LAUNCHDARKLY_SDK_KEY P6_DFZ_PROFILE_LAUNCHDARKLY P6_LD_ENV P6_LD_PROJECT
-#>
-######################################################################
-p6df::modules::launchdarkly::prompt::mod() {
-
-  local str
-  if p6_string_blank_NOT "$P6_DFZ_PROFILE_LAUNCHDARKLY"; then
-    if p6_string_blank_NOT "$P6_LD_PROJECT"; then
-      str="launchdarkly:\t  $P6_DFZ_PROFILE_LAUNCHDARKLY:"
-      str=$(p6_string_append "$str" "$P6_LD_PROJECT" " ")
-    fi
-    if p6_string_blank_NOT "$P6_LD_ENV"; then
-      str=$(p6_string_append "$str" "$P6_LD_ENV" "/")
-    fi
-    if p6_string_blank_NOT "$LAUNCHDARKLY_API_KEY"; then
-      str=$(p6_string_append "$str" "api" "/")
-    fi
-    if p6_string_blank_NOT "$LAUNCHDARKLY_SDK_KEY"; then
-      str=$(p6_string_append "$str" "sdk" "/")
-    fi
-  fi
-
-  p6_return_str "$str"
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::launchdarkly::mcp()
 #
 #>
@@ -112,42 +59,29 @@ p6df::modules::launchdarkly::mcp() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::launchdarkly::profile::on(profile, code)
+# Function: words launchdarkly $LAUNCHDARKLY_API_KEY = p6df::modules::launchdarkly::profile::mod()
 #
-#  Args:
-#	profile -
-#	code -
+#  Returns:
+#	words - launchdarkly $LAUNCHDARKLY_API_KEY
 #
-#  Environment:	 P6_DFZ_PROFILE_LAUNCHDARKLY
+#  Environment:	 LAUNCHDARKLY_API_KEY
 #>
 ######################################################################
-p6df::modules::launchdarkly::profile::on() {
-  local profile="$1"
-  local code="$2"
+p6df::modules::launchdarkly::profile::mod() {
 
-  p6_run_code "$code"
+  local str
+  if p6_string_blank_NOT "$P6_LD_PROJECT"; then
+    str="$(p6_string_space_pad "launchdarkly:" 16)$P6_LD_PROJECT"
+  fi
+  if p6_string_blank_NOT "$P6_LD_ENV"; then
+    str=$(p6_string_append "$str" "$P6_LD_ENV" "/")
+  fi
+  if p6_string_blank_NOT "$LAUNCHDARKLY_API_KEY"; then
+    str=$(p6_string_append "$str" "api" "/")
+  fi
+  if p6_string_blank_NOT "$LAUNCHDARKLY_SDK_KEY"; then
+    str=$(p6_string_append "$str" "sdk" "/")
+  fi
 
-  p6_env_export "P6_DFZ_PROFILE_LAUNCHDARKLY" "$profile"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::profile::off(code)
-#
-#  Args:
-#	code - shell code block previously passed to profile::on
-#
-#  Environment:	 LAUNCHDARKLY_API_KEY LAUNCHDARKLY_SDK_KEY P6_DFZ_PROFILE_LAUNCHDARKLY P6_LD_ENV P6_LD_PROJECT
-#>
-######################################################################
-p6df::modules::launchdarkly::profile::off() {
-  local code="$1"
-
-  p6_env_unset_from_code "$code"
-  p6_env_export_un P6_DFZ_PROFILE_LAUNCHDARKLY
-
-  p6_return_void
+  p6_return_str "$str"
 }


### PR DESCRIPTION
## What
Removes `init()`, `prompt::mod()`, `profile::on()`, and `profile::off()` functions and replaces them with `profile::mod()` that returns LD project/env/api/sdk info via `p6_return_str`. Adds `p6m7g8-dotfiles/p6common` to `ModuleDeps`.

## Why
Standardizes LaunchDarkly module to the `profile::mod` pattern, removing legacy profile lifecycle functions no longer part of the framework convention.

## Test plan
- Reviewed diff manually
- Existing logic for building the LD prompt string is preserved in `profile::mod`

## Dependencies
None