### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,21 +1,9 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::deps()
-#
-#>
-######################################################################
 p6df::modules::launchdarkly::deps() {
   ModuleDeps=(p6m7g8-dotfiles/p6common)
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::external::brews()
-#
-#>
 ######################################################################
 p6df::modules::launchdarkly::external::brews() {
 
@@ -25,26 +13,6 @@ p6df::modules::launchdarkly::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::vscodes()
-#
-#>
-######################################################################
-p6df::modules::launchdarkly::vscodes() {
-
-         p6df::modules::vscode::extension::install LaunchDarklyOfficial.launchdarkly
-
-         p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::mcp()
-#
-#>
 ######################################################################
 p6df::modules::launchdarkly::mcp() {
 
@@ -57,15 +25,13 @@ p6df::modules::launchdarkly::mcp() {
 }
 
 ######################################################################
-#<
-#
-# Function: words launchdarkly $LAUNCHDARKLY_API_KEY = p6df::modules::launchdarkly::profile::mod()
-#
-#  Returns:
-#	words - launchdarkly $LAUNCHDARKLY_API_KEY
-#
-#  Environment:	 LAUNCHDARKLY_API_KEY
-#>
+p6df::modules::launchdarkly::vscodes() {
+
+         p6df::modules::vscode::extension::install LaunchDarklyOfficial.launchdarkly
+
+         p6_return_void
+}
+
 ######################################################################
 p6df::modules::launchdarkly::profile::mod() {
 
@@ -85,3 +51,37 @@ p6df::modules::launchdarkly::profile::mod() {
 
   p6_return_str "$str"
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::mcp()
+#
+#>
+######################################################################
+#<
+#
+# Function: words launchdarkly $LAUNCHDARKLY_API_KEY = p6df::modules::launchdarkly::profile::mod()
+#
+#  Returns:
+#	words - launchdarkly $LAUNCHDARKLY_API_KEY
+#
+#  Environment:	 LAUNCHDARKLY_API_KEY
+#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,9 +1,21 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::deps()
+#
+#>
+######################################################################
 p6df::modules::launchdarkly::deps() {
   ModuleDeps=(p6m7g8-dotfiles/p6common)
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::launchdarkly::external::brews() {
 
@@ -13,6 +25,12 @@ p6df::modules::launchdarkly::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::mcp()
+#
+#>
 ######################################################################
 p6df::modules::launchdarkly::mcp() {
 
@@ -25,6 +43,12 @@ p6df::modules::launchdarkly::mcp() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::launchdarkly::vscodes()
+#
+#>
+######################################################################
 p6df::modules::launchdarkly::vscodes() {
 
          p6df::modules::vscode::extension::install LaunchDarklyOfficial.launchdarkly
@@ -32,6 +56,16 @@ p6df::modules::launchdarkly::vscodes() {
          p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: words launchdarkly $LAUNCHDARKLY_API_KEY = p6df::modules::launchdarkly::profile::mod()
+#
+#  Returns:
+#	words - launchdarkly $LAUNCHDARKLY_API_KEY
+#
+#  Environment:	 LAUNCHDARKLY_API_KEY
+#>
 ######################################################################
 p6df::modules::launchdarkly::profile::mod() {
 
@@ -51,37 +85,3 @@ p6df::modules::launchdarkly::profile::mod() {
 
   p6_return_str "$str"
 }
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::launchdarkly::mcp()
-#
-#>
-######################################################################
-#<
-#
-# Function: words launchdarkly $LAUNCHDARKLY_API_KEY = p6df::modules::launchdarkly::profile::mod()
-#
-#  Returns:
-#	words - launchdarkly $LAUNCHDARKLY_API_KEY
-#
-#  Environment:	 LAUNCHDARKLY_API_KEY
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None